### PR TITLE
Update to psqlodbc95

### DIFF
--- a/SPECS/psqlodbc95.spec
+++ b/SPECS/psqlodbc95.spec
@@ -1,5 +1,5 @@
 Summary: A complete ODBC driver manager for Linux
-Name: psqlodbc
+Name: psqlodbc95
 Version: %{?version}%{!?version:09.05.0100}
 Release: 1%{?dist}
 Group: System Environment/Libraries
@@ -8,8 +8,8 @@ License: LGPLv2+
 
 Source: https://ftp.postgresql.org/pub/odbc/versions/src/%{name}-%{version}.tar.gz
 
-Conflicts: postgresql-odbc postgresql94-odbc
-BuildRequires: automake autoconf libtool postgresql94-devel
+Conflicts: postgresql-odbc postgresql95-odbc psqlodbc
+BuildRequires: automake autoconf libtool postgresql95-devel
 BuildRequires: unixODBC-devel >= 2.3.4-1
 Requires: unixODBC >= 2.3.4-1
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
@@ -21,7 +21,7 @@ This package installs the PostgreSQL ODBC library
 %setup -q
 
 %build
-%configure --enable-pthreads --with-libpq=/usr/pgsql-9.4 --with-unixodbc=/usr/bin/odbc_config
+%configure --enable-pthreads --with-libpq=/usr/pgsql-9.5 --with-unixodbc=/usr/bin/odbc_config
 make all
 
 %install

--- a/mock/el6-x86_64-psqlodbc.cfg
+++ b/mock/el6-x86_64-psqlodbc.cfg
@@ -1,10 +1,10 @@
 config_opts['root'] = 'el6-x86_64-pg'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
-config_opts['chroot_setup_cmd'] = 'install @buildsys-build autoconf automake libtool postgresql94-devel unixODBC-devel'
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build autoconf automake libtool postgresql95-devel unixODBC-devel'
 config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '6'
-config_opts['environment']['PATH'] = '/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/pgsql-9.4/bin'
+config_opts['environment']['PATH'] = '/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/pgsql-9.5/bin'
 
 config_opts['yum.conf'] = """
 [main]
@@ -61,20 +61,20 @@ mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-6&arch=x8
 failovermethod=priority
 enabled=0
 
-[pgdg94]
-name=PostgreSQL 9.4 $releasever - $basearch
-baseurl=http://yum.postgresql.org/9.4/redhat/rhel-$releasever-$basearch
+[pgdg95]
+name=PostgreSQL 9.5 $releasever - $basearch
+baseurl=http://yum.postgresql.org/9.5/redhat/rhel-$releasever-$basearch
 enabled=1
 gpgcheck=1
-gpgkey=http://yum.postgresql.org/RPM-GPG-KEY-PGDG-94
+gpgkey=http://yum.postgresql.org/RPM-GPG-KEY-PGDG-95
 
-[pgdg94-source]
-name=PostgreSQL 9.4 $releasever - $basearch - Source
+[pgdg95-source]
+name=PostgreSQL 9.5 $releasever - $basearch - Source
 failovermethod=priority
-baseurl=http://yum.postgresql.org/srpms/9.4/redhat/rhel-$releasever-$basearch
+baseurl=http://yum.postgresql.org/srpms/9.5/redhat/rhel-$releasever-$basearch
 enabled=0
 gpgcheck=1
-gpgkey=http://yum.postgresql.org/RPM-GPG-KEY-PGDG-94
+gpgkey=http://yum.postgresql.org/RPM-GPG-KEY-PGDG-95
 
 [immuta-internal]
 name=immuta

--- a/mock/el7-x86_64-psqlodbc.cfg
+++ b/mock/el7-x86_64-psqlodbc.cfg
@@ -1,10 +1,10 @@
 config_opts['root'] = 'el7-x86_64-psqlodbc'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
-config_opts['chroot_setup_cmd'] = 'install @buildsys-build autoconf automake libtool postgresql94-devel unixODBC-devel'
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build autoconf automake libtool postgresql95-devel unixODBC-devel'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
-config_opts['environment']['PATH'] = '/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/pgsql-9.4/bin'
+config_opts['environment']['PATH'] = '/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/pgsql-9.5/bin'
 
 config_opts['macros']['%dist'] = '.el7'
 
@@ -69,20 +69,20 @@ mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-7&arch=x8
 failovermethod=priority
 enabled=0
 
-[pgdg94]
-name=PostgreSQL 9.4 $releasever - $basearch
-baseurl=http://yum.postgresql.org/9.4/redhat/rhel-$releasever-$basearch
+[pgdg95]
+name=PostgreSQL 9.5 $releasever - $basearch
+baseurl=http://yum.postgresql.org/9.5/redhat/rhel-$releasever-$basearch
 enabled=1
 gpgcheck=1
-gpgkey=http://yum.postgresql.org/RPM-GPG-KEY-PGDG-94
+gpgkey=http://yum.postgresql.org/RPM-GPG-KEY-PGDG-95
 
 [pgdg94-source]
-name=PostgreSQL 9.4 $releasever - $basearch - Source
+name=PostgreSQL 9.5 $releasever - $basearch - Source
 failovermethod=priority
-baseurl=http://yum.postgresql.org/srpms/9.4/redhat/rhel-$releasever-$basearch
+baseurl=http://yum.postgresql.org/srpms/9.5/redhat/rhel-$releasever-$basearch
 enabled=0
 gpgcheck=1
-gpgkey=http://yum.postgresql.org/RPM-GPG-KEY-PGDG-94
+gpgkey=http://yum.postgresql.org/RPM-GPG-KEY-PGDG-95
 
 [immuta-internal]
 name=immuta


### PR DESCRIPTION
This change moves the psqlodbc libraries to build against PostgreSQL
9.5 instead of 9.4. To facilitate, we're moving the package name to
psqlodbc95 from simply psqlodbc.

@immuta/devops @immuta/developers 