### PR TITLE
Update RPM Process

### DIFF
--- a/SPECS/psqlodbc95.spec
+++ b/SPECS/psqlodbc95.spec
@@ -1,6 +1,6 @@
 Summary: A complete ODBC driver manager for Linux
 Name: psqlodbc95
-Version: %{?version}%{!?version:09.05.0100}
+Version: %{?version}%{!?version:09.05.0300}
 Release: 1%{?dist}
 Group: System Environment/Libraries
 URL: https://odbc.postgresql.org/
@@ -10,8 +10,8 @@ Source: https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-%{version}.tar
 
 Conflicts: postgresql-odbc postgresql95-odbc psqlodbc
 BuildRequires: automake autoconf libtool postgresql95-devel
-BuildRequires: unixODBC-devel >= 2.3.4-1
-Requires: unixODBC >= 2.3.4-1
+BuildRequires: unixODBC-devel
+Requires: unixODBC
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 %description

--- a/mock/el6-x86_64-psqlodbc.cfg
+++ b/mock/el6-x86_64-psqlodbc.cfg
@@ -75,11 +75,4 @@ baseurl=http://yum.postgresql.org/srpms/9.5/redhat/rhel-$releasever-$basearch
 enabled=0
 gpgcheck=1
 gpgkey=http://yum.postgresql.org/RPM-GPG-KEY-PGDG-95
-
-[immuta-internal]
-name=immuta
-baseurl=http://yum.immuta.com/yum/immuta/6
-enabled=1
-gpgcheck=1
-gpgkey=http://yum.immuta.com/yum/immuta/GPGKEYS/RPM-GPG-KEY-Immuta-Development
 """

--- a/mock/el7-x86_64-psqlodbc.cfg
+++ b/mock/el7-x86_64-psqlodbc.cfg
@@ -76,18 +76,11 @@ enabled=1
 gpgcheck=1
 gpgkey=http://yum.postgresql.org/RPM-GPG-KEY-PGDG-95
 
-[pgdg94-source]
+[pgdg95-source]
 name=PostgreSQL 9.5 $releasever - $basearch - Source
 failovermethod=priority
 baseurl=http://yum.postgresql.org/srpms/9.5/redhat/rhel-$releasever-$basearch
 enabled=0
 gpgcheck=1
 gpgkey=http://yum.postgresql.org/RPM-GPG-KEY-PGDG-95
-
-[immuta-internal]
-name=immuta
-baseurl=http://yum.immuta.com/yum/immuta/7
-enabled=1
-gpgcheck=1
-gpgkey=http://yum.immuta.com/yum/immuta/GPGKEYS/RPM-GPG-KEY-Immuta-Development
 """


### PR DESCRIPTION
This PR updates the psqlodbc95 builds to use by default the 0300 release and removes the dependency on internally build unixODBC and rather defaults to use the unixODBC included with the EL linux repositories.

@immuta/devops @immuta/developers 